### PR TITLE
Mirex2019

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ To run:
 1. run `pip install -r requirements.txt`. 
 2. Make a file named `config.py` and define the following:
 ```python
+# Location to write output to
+OUTPUT_FOLDER = ''
 # point the dataset path to the appropriate path on your file system
 DATASET_PATH = "path/to/the/evaluation/set"
 # model_dirs is a dictionary with the tested model as key,
@@ -31,3 +33,4 @@ DISCRIM_POLY_FILES = {
 }
 ```
 3. Then run `python evaluate_prediction.py`. This will calculate the measures and render them as graphs. On Mac OS X, Matplotlib may still need to be configured, see [Matplotlib FAQ](https://matplotlib.org/faq/osx_framework.html). Code tested in Python 3.5.4.
+4. Finally run `python evaluate_discrimination.py`

--- a/evaluate_discrimination.py
+++ b/evaluate_discrimination.py
@@ -25,31 +25,6 @@ import numpy as np
 import pandas as pd
 
 import config
-
-
-
-SMALLEST_NUMBER = np.finfo(float).eps
-
-
-
-def softmax(x, axis=-1):
-    """Returns the softmax for each row of the input x. For numerical
-    stability, we subtract the maximum value from each row first before getting
-    the exponents.
-    """
-    exp = np.exp(x - np.max(x, axis=axis, keepdims=True))
-    return exp / np.sum(exp, axis=axis, keepdims=True)
-
-
-def negloglike(x, labels):
-    """Returns the negative log likelihood from each row of x (unnormalized
-    probabilities - we apply a softmax to each row first).
-    """
-    # TODO: note that it is assumed every row has already been normalized
-#    probs = softmax(x)
-    probs = x
-    # select only the prob of true lab
-    return -np.log(probs[:, labels] + SMALLEST_NUMBER)
     
 
 def get_scores(x, labels=None):
@@ -64,18 +39,8 @@ def get_scores(x, labels=None):
     if labels is None:
         labels = max_idx * np.ones(nr_obs, dtype=int)
     accuracy = np.mean(np.argmax(x, axis=-1) == labels)
-    nll = negloglike(x, labels)
-    crossent = np.mean(nll)
-    # Renormalising and making 1 best and 0 worst
-    worst_crossent = -np.log(SMALLEST_NUMBER)
-    best_crossent = -np.log(1 + SMALLEST_NUMBER)
-    # renormalise
-    crossent_score = ((crossent - best_crossent) /
-                      (worst_crossent - best_crossent))
-    # reverse
-    crossent_score = 1 - crossent_score
-#    nll_var = np.var(nll)
-    return nr_obs, accuracy, crossent_score
+    avg_prob = np.mean(x[:, labels])
+    return nr_obs, accuracy, avg_prob
 
 
 if __name__ == '__main__':
@@ -86,7 +51,7 @@ if __name__ == '__main__':
     
     # Score each file
     scores = pd.DataFrame(
-        columns=['model', 'data', 'nr_obs', 'accuracy', 'crossentropy_score'],
+        columns=['model', 'data', 'nr_obs', 'accuracy', 'avg_probability'],
         dtype=float
     )
     scores.nr_obs = scores.nr_obs.astype(int)

--- a/evaluate_discrimination.py
+++ b/evaluate_discrimination.py
@@ -40,7 +40,8 @@ def get_scores(x, labels=None):
         labels = max_idx * np.ones(nr_obs, dtype=int)
     accuracy = np.mean(np.argmax(x, axis=-1) == labels)
     avg_prob = np.mean(x[:, labels])
-    return nr_obs, accuracy, avg_prob
+    var_prob = np.var(x[:, labels])
+    return nr_obs, accuracy, avg_prob, var_prob
 
 
 if __name__ == '__main__':
@@ -51,7 +52,8 @@ if __name__ == '__main__':
     
     # Score each file
     scores = pd.DataFrame(
-        columns=['model', 'data', 'nr_obs', 'accuracy', 'avg_probability'],
+        columns=['model', 'data', 'nr_obs', 'accuracy', 'mean_probability',
+                 'var_prob'],
         dtype=float
     )
     scores.nr_obs = scores.nr_obs.astype(int)

--- a/evaluate_discrimination.py
+++ b/evaluate_discrimination.py
@@ -15,6 +15,9 @@ The input data files are expected to be of the format:
 Where id represents the identity of the exerpt being evaluated, the final
 column is the true continuation score, and all other columns are false
 continuation scores.
+
+N.B. It is assumed that the rows sum to 1, with the values representing the
+probability of each excerpt being the true continuation.
 """
 import os.path as op
 
@@ -22,6 +25,10 @@ import numpy as np
 import pandas as pd
 
 import config
+
+
+
+SMALLEST_NUMBER = np.finfo(float).eps
 
 
 
@@ -38,8 +45,11 @@ def negloglike(x, labels):
     """Returns the negative log likelihood from each row of x (unnormalized
     probabilities - we apply a softmax to each row first).
     """
-    probs = softmax(x)
-    return -np.log(probs[:, labels])  # select only the prob of true lab
+    # TODO: note that it is assumed every row has already been normalized
+#    probs = softmax(x)
+    probs = x
+    # select only the prob of true lab
+    return -np.log(probs[:, labels] + SMALLEST_NUMBER)
     
 
 def get_scores(x, labels=None):
@@ -56,8 +66,16 @@ def get_scores(x, labels=None):
     accuracy = np.mean(np.argmax(x, axis=-1) == labels)
     nll = negloglike(x, labels)
     crossent = np.mean(nll)
-    nll_var = np.var(nll)
-    return nr_obs, accuracy, crossent, nll_var
+    # Renormalising and making 1 best and 0 worst
+    worst_crossent = -np.log(SMALLEST_NUMBER)
+    best_crossent = -np.log(1 + SMALLEST_NUMBER)
+    # renormalise
+    crossent_score = ((crossent - best_crossent) /
+                      (worst_crossent - best_crossent))
+    # reverse
+    crossent_score = 1 - crossent_score
+#    nll_var = np.var(nll)
+    return nr_obs, accuracy, crossent_score
 
 
 if __name__ == '__main__':
@@ -68,8 +86,7 @@ if __name__ == '__main__':
     
     # Score each file
     scores = pd.DataFrame(
-        columns=['model', 'data', 'nr_obs', 'accuracy', 'crossentropy',
-                 'nll_var'],
+        columns=['model', 'data', 'nr_obs', 'accuracy', 'crossentropy_score'],
         dtype=float
     )
     scores.nr_obs = scores.nr_obs.astype(int)
@@ -82,10 +99,19 @@ if __name__ == '__main__':
         for model_name, fn in files.items():
             df = pd.read_csv(fn)
             x = df.iloc[:, 1:].values
+            assert np.allclose(np.sum(x, axis=1), np.ones(x.shape[0])), (
+                f'Rows in {model_name} discrim file do not sum to one. '
+                'It is expected each value represents the probability of the '
+                'each excerpt being the true continuation so rows should sum '
+                'to one.')
             scores.loc[(model_name, data_type), :] = get_scores(x)
     
     # TODO: Check files have same set of ids (warn if not)
     
     # Output table of results
-    scores.round(decimals=3).to_html(op.join(config.OUTPUT_FOLDER, 'discrim_table.html'))
-    scores.round(decimals=3).to_latex(op.join(config.OUTPUT_FOLDER, 'discrim_table.tex'))
+    scores.round(decimals=3).to_html(op.join(config.OUTPUT_FOLDER,
+                'discrim_table.html'))
+    scores.round(decimals=3).to_latex(op.join(config.OUTPUT_FOLDER,
+                'discrim_table.tex'))
+
+    print(scores.round(decimals=3))


### PR DESCRIPTION
~Before I assumed that the files provided were pre normalization, but
examples provided looked to have already been softmaxed. The best
crossentropy is 0, the worst is infinite. I have added a tiny
constant to allow for the case where a model assigns 0 probability
then renormalized such that the 'crossentropy_score' ranges from
0 to 1 and the best value is 1.~

Scratch that, when you rescale (i.e. move from log space back to probability space), we end up just taking the average of the probability. I feel a bit of an idiot :joy:. This score is much better since the non informative model (predicts .5 for everything) gets a score of .5. 